### PR TITLE
Adding default text when message content is empty

### DIFF
--- a/queries.py
+++ b/queries.py
@@ -141,7 +141,6 @@ def construct_insert_conversatie_query(graph_uri, conversatie, bericht, delivery
     conversatie['current_type_communicatie'] =\
         escape_helpers.sparql_escape_string(conversatie['current_type_communicatie'])
     bericht = copy.deepcopy(bericht)  # For not modifying the pass-by-name original
-    bericht['inhoud'] = escape_helpers.sparql_escape_string(bericht['inhoud']) or "Origineel bericht in bijlage."
     q = """
         PREFIX schema: <http://schema.org/>
         PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -167,7 +166,7 @@ def construct_insert_conversatie_query(graph_uri, conversatie, bericht, delivery
                     <http://mu.semte.ch/vocabularies/core/uuid> "{2[uuid]}";
                     schema:dateSent "{2[verzonden]}"^^xsd:dateTime;
                     schema:dateReceived "{2[ontvangen]}"^^xsd:dateTime;
-                    schema:text {2[inhoud]};
+                    schema:text "Origineel bericht in bijlage";
                     <http://purl.org/dc/terms/type> "{2[type_communicatie]}";
                     schema:sender <{2[van]}>;
                     schema:recipient <{2[naar]}>;
@@ -191,7 +190,6 @@ def construct_insert_bericht_query(graph_uri, bericht, conversatie_uri, delivery
     :returns: string containing SPARQL query
     """
     bericht = copy.deepcopy(bericht)  # For not modifying the pass-by-name original
-    bericht['inhoud'] = escape_helpers.sparql_escape_string(bericht['inhoud'])
     q = """
         PREFIX schema: <http://schema.org/>
         PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
@@ -205,7 +203,7 @@ def construct_insert_bericht_query(graph_uri, bericht, conversatie_uri, delivery
                     <http://mu.semte.ch/vocabularies/core/uuid> "{1[uuid]}";
                     schema:dateSent "{1[verzonden]}"^^xsd:dateTime;
                     schema:dateReceived "{1[ontvangen]}"^^xsd:dateTime;
-                    schema:text {1[inhoud]};
+                    schema:text "Origineel bericht in bijlage";
                     schema:sender <{1[van]}>;
                     schema:recipient <{1[naar]}>;
                     adms:status <{3}>;

--- a/queries.py
+++ b/queries.py
@@ -141,7 +141,7 @@ def construct_insert_conversatie_query(graph_uri, conversatie, bericht, delivery
     conversatie['current_type_communicatie'] =\
         escape_helpers.sparql_escape_string(conversatie['current_type_communicatie'])
     bericht = copy.deepcopy(bericht)  # For not modifying the pass-by-name original
-    bericht['inhoud'] = escape_helpers.sparql_escape_string(bericht['inhoud'])
+    bericht['inhoud'] = escape_helpers.sparql_escape_string(bericht['inhoud']) or "Origineel bericht in bijlage."
     q = """
         PREFIX schema: <http://schema.org/>
         PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>


### PR DESCRIPTION
# Description
DL-5409

This PR adds a fallback message when `inhoud` (content) is empty.

See property : `schema:text` of "bericht" (message) model


# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A

# How to test 

1. Add to the service in your loket docker-compose.override.yml
```yml
services:
  berichtencentrum-sync-with-kalliope:
    command: tail -f /dev/null
```
   **optional** : you can set a breakpoint with importing pdb and adding pdb.set_trace() where the function is executed.

2. Run this service on loket by building it as a docker image.
3. Run the command `drc exec berichtencentrum-sync-with-kalliope bash`
4. Then, `python web.py` in the container
5. Create a fake bericht but without a `schema:text` value : See `20181228208000-mock-conversaties.sparql` migration

Example: 

```sparql
INSERT DATA {
  GRAPH <http://mu.semte.ch/graphs/organizations/aa368412c2a6d17d41b78030f2914211a77e5cda29c673afc49bf4ac655bc913/LoketLB-berichtenGebruiker> {
    <http://data.lblod.info/id/conversaties/1> a <http://schema.org/Conversation>;
       <http://mu.semte.ch/vocabularies/core/uuid> "634e983e-d7e5-4cba-9a2f-c1cfde73068d";
       <http://schema.org/identifier> "2018.00301";
       <http://schema.org/about> "Meerjarenplanwijziging 2014-2018";
       <http://purl.org/dc/terms/type> "Opvraging in kader van een toezichtsdossier";
       <http://schema.org/processingTime> "P30D";
       <http://schema.org/hasPart> <http://data.lblod.info/id/berichten/1>;
       <http://mu.semte.ch/vocabularies/ext/lastMessage> <http://data.lblod.info/id/berichten/1>.

    <http://data.lblod.info/id/berichten/1> a <http://schema.org/Message>;
       <http://mu.semte.ch/vocabularies/core/uuid> "634e983e-d7e5-4cba-9a2f-c1cfde73068e";
       <http://schema.org/dateSent> "2018-12-06T09:00:00"^^xsd:dateTime;
       <http://schema.org/dateReceived> "2018-12-06T09:00:00"^^xsd:dateTime;
       <http://schema.org/sender> <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>;
       <http://schema.org/recipient> <http://data.lblod.info/id/bestuurseenheden/aa368412c2a6d17d41b78030f2914211a77e5cda29c673afc49bf4ac655bc913>.
  }
}

```

6. Query your fake bericht, `schema:text` should now contain "Origineel bericht in bijlage." when the field is empty.

# What to check

- N/A

# Links to other PR's

- N/A

# Notes

drc up -d berichtencentrum-sync-with-kalliope
