### PR TITLE
Adding extra exclusion rules for worship submissions

### DIFF
--- a/queries.py
+++ b/queries.py
@@ -20,27 +20,32 @@ STATUS_DELIVERED_CONFIRMATION_FAILED = \
 # Inzendingen business rules :  sender classification with decisionType
 
 DECISION_TYPES_EB_HAS_CB = [
-    "<https://data.vlaanderen.be/id/concept/BesluitType/e44c535d-4339-4d15-bdbf-d4be6046de2c>",
-    "<https://data.vlaanderen.be/id/concept/BesluitDocumentType/2c9ada23-1229-4c7e-a53e-acddc9014e4e>"           
+    "<https://data.vlaanderen.be/id/concept/BesluitType/e44c535d-4339-4d15-bdbf-d4be6046de2c>", # Jaarrekening
+    "<https://data.vlaanderen.be/id/concept/BesluitDocumentType/2c9ada23-1229-4c7e-a53e-acddc9014e4e>" # Gecoordineerde inzending meerjarenplannen
+]
+
+DECISION_TYPES_EB = [
+    "<https://data.vlaanderen.be/id/concept/BesluitType/f56c645d-b8e1-4066-813d-e213f5bc529f>" # Meerjarenplan(aanpassing)
 ]
 
 DECISION_TYPES_CB = [
-    "<https://data.vlaanderen.be/id/concept/BesluitDocumentType/18833df2-8c9e-4edd-87fd-b5c252337349>",
-    "<https://data.vlaanderen.be/id/concept/BesluitDocumentType/2c9ada23-1229-4c7e-a53e-acddc9014e4e>"
+    "<https://data.vlaanderen.be/id/concept/BesluitDocumentType/18833df2-8c9e-4edd-87fd-b5c252337349>", # Budgetten(wijzigingen) - Indiening bij representatief orgaan
+    "<https://data.vlaanderen.be/id/concept/BesluitDocumentType/2c9ada23-1229-4c7e-a53e-acddc9014e4e>" # Gecoordineerde inzending meerjarenplannen
 ]
 
 DECISION_TYPES_RO = [
-    "<https://data.vlaanderen.be/id/concept/BesluitType/2b12630f-8c4e-40a4-8a61-a0c45621a1e6>"
+    "<https://data.vlaanderen.be/id/concept/BesluitType/2b12630f-8c4e-40a4-8a61-a0c45621a1e6>", # Advies Budget(wijziging)
+    "<https://data.vlaanderen.be/id/concept/BesluitType/0fc2c27d-a03c-4e3f-9db1-f10f026f76f8>" # Advies Meerjarenplan
 ]
 
 DECISION_TYPES_GO = [
-    "<https://data.vlaanderen.be/id/concept/BesluitType/df261490-cc74-4f80-b783-41c35e720b46>",
-    "<https://data.vlaanderen.be/id/concept/BesluitType/3fcf7dba-2e5b-4955-a489-6dd8285c013b>"
+    "<https://data.vlaanderen.be/id/concept/BesluitType/df261490-cc74-4f80-b783-41c35e720b46>", # Besluit over budget(wijziging) eredienstbestuur
+    "<https://data.vlaanderen.be/id/concept/BesluitType/3fcf7dba-2e5b-4955-a489-6dd8285c013b>" # Besluit over meerjarenplan(aanpassing) eredienstbestuur
 ]
 
 DECISION_TYPES_PO = [
-    "<https://data.vlaanderen.be/id/concept/BesluitType/df261490-cc74-4f80-b783-41c35e720b46>",
-    "<https://data.vlaanderen.be/id/concept/BesluitType/3fcf7dba-2e5b-4955-a489-6dd8285c013b>"
+    "<https://data.vlaanderen.be/id/concept/BesluitType/df261490-cc74-4f80-b783-41c35e720b46>", # Besluit over budget(wijziging) eredienstbestuur
+    "<https://data.vlaanderen.be/id/concept/BesluitType/3fcf7dba-2e5b-4955-a489-6dd8285c013b>" # Besluit over meerjarenplan(aanpassing) eredienstbestuur
 ]
 
 
@@ -518,6 +523,33 @@ def verify_eb_has_cb_exclusion_rule(submission):
     """.format(submission, " ".join(DECISION_TYPES_EB_HAS_CB))
 
     return ask_query_eb_has_cb
+
+def verify_eb_exclusion_rule(submission):
+
+    ask_query_eb = """
+    PREFIX ere:         <http://data.lblod.info/vocabularies/erediensten/>
+    PREFIX pav:         <http://purl.org/pav/>
+    PREFIX meb:         <http://rdf.myexperiment.org/ontologies/base/>
+    PREFIX dct:         <http://purl.org/dc/terms/>
+    PREFIX prov:        <http://www.w3.org/ns/prov#>
+    PREFIX adms:        <http://www.w3.org/ns/adms#>
+    
+    ASK {{
+
+        BIND(<{0}> AS ?submission)
+        ?submission a meb:Submission ;
+                   adms:status <http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c> ;
+                   prov:generated ?formData ;
+                   pav:createdBy ?bestuurseenheid .
+        ?formData dct:type ?decisionType .
+        VALUES ?decisionType {{ {1} }}
+
+        ?bestuurseenheid a ere:BestuurVanDeEredienst.
+
+    }}
+    """.format(submission, " ".join(DECISION_TYPES_EB))
+
+    return ask_query_eb
 
 def verify_cb_exclusion_rule(submission):
 

--- a/task_process_inzendingen_voor_toezicht.py
+++ b/task_process_inzendingen_voor_toezicht.py
@@ -10,6 +10,7 @@ from .queries import construct_increment_inzending_attempts_query
 from .queries import construct_inzending_sent_query
 from .queries import construct_create_kalliope_sync_error_query
 from .queries import verify_eb_has_cb_exclusion_rule
+from .queries import verify_eb_exclusion_rule
 from .queries import verify_cb_exclusion_rule
 from .queries import verify_ro_exclusion_rule
 from .queries import verify_go_exclusion_rule
@@ -129,13 +130,14 @@ def exclude_inzendingen_from_rules(inzendingen):
         submission = inzending['inzending']['value']
 
         eb_has_cb = query(verify_eb_has_cb_exclusion_rule(submission))['boolean']
+        eb = query(verify_eb_exclusion_rule(submission))['boolean']
         cb = query(verify_cb_exclusion_rule(submission))['boolean']
         ro = query(verify_ro_exclusion_rule(submission))['boolean']
         go = query(verify_go_exclusion_rule(submission))['boolean']
         po = query(verify_po_exclusion_rule(submission))['boolean']
 
 
-        if not (eb_has_cb or cb or ro or go or po):
+        if not (eb_has_cb or eb or cb or ro or go or po):
             filtered_inzendingen.append(inzending)
 
     return filtered_inzendingen


### PR DESCRIPTION
# Description
DL-5560
Sub stories -> DL-5561 - DL-5562 - DL-5563

This PR filters out worship submissions that contains these URIs with specific rules : 
- https://data.vlaanderen.be/id/concept/BesluitType/e44c535d-4339-4d15-bdbf-d4be6046de2c> # Jaarrekening - Rule : sender EB that has CB
- https://data.vlaanderen.be/id/concept/BesluitType/f56c645d-b8e1-4066-813d-e213f5bc529f # Meerjarenplan(aanpassing) - Rule : sender EB with and without CB
- https://data.vlaanderen.be/id/concept/BesluitDocumentType/2c9ada23-1229-4c7e-a53e-acddc9014e4e # Gecoordineerde inzending meerjarenplannen - Rule : sender CB
- https://data.vlaanderen.be/id/concept/BesluitType/0fc2c27d-a03c-4e3f-9db1-f10f026f76f8 # Advies Meerjarenplan - Rule : sender RO
- https://data.vlaanderen.be/id/concept/BesluitType/2b12630f-8c4e-40a4-8a61-a0c45621a1e6> # Advies Budget(wijziging) - Rule : sender RO

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A

# How to test 

1. Add to the service in your loket docker-compose.override.yml
```yml
services:
  berichtencentrum-sync-with-kalliope:
    command: tail -f /dev/null
    environment:
      INZENDINGEN_CRON_PATTERN: "*/5 * * * *"
```
   **optional** : you can set a breakpoint with importing pdb and adding pdb.set_trace() where the function is executed.

2. Run this service on loket by building it as a docker image.
3. Run the command `drc exec berichtencentrum-sync-with-kalliope bash`
4. Then, `python web.py` in the container
5. It should filter out submissions

# What to check

- N/A

# Links to other PR's

- N/A

# Notes

drc up -d berichtencentrum-sync-with-kalliope
