### PR TITLE
fix query wrongly optimized by virtuoso

### DIFF
--- a/queries.py
+++ b/queries.py
@@ -311,30 +311,32 @@ def construct_update_last_bericht_query(conversatie_uri):
 
         DELETE {{
             GRAPH ?g {{
-                ?conversation ext:lastMessage ?message.
+                ?conversation ext:lastMessage ?oldMessage.
             }}
         }}
         INSERT {{
             GRAPH ?g {{
-                ?conversation ext:lastMessage ?newMessage.
+                ?conversation ext:lastMessage ?message.
             }}
         }}
         WHERE {{
-            BIND(<{0}> as ?conversation)
-            GRAPH ?g {{
-                ?conversation a schema:Conversation;
-                    schema:hasPart ?newMessage.
-                OPTIONAL {{  ?conversation ext:lastMessage ?message. }}
-            }}
             {{
-              SELECT DISTINCT (?message AS ?newMessage) ?dateSent WHERE {{
+              SELECT DISTINCT ?conversation ?message WHERE {{
+               BIND(<{0}> as ?conversation)
                 ?conversation a schema:Conversation;
                   schema:hasPart ?message.
-
                 ?message schema:dateSent ?dateSent.
               }}
               ORDER BY DESC(?dateSent)
               LIMIT 1
+            }}
+
+            GRAPH ?g {{
+                ?conversation a schema:Conversation;
+                   schema:hasPart ?message.
+                OPTIONAL {{
+                  ?conversation ext:lastMessage ?oldMessage.
+                }}
             }}
         }}
         """.format(conversatie_uri)


### PR DESCRIPTION
See https://github.com/blazegraph/database/wiki/SPARQL_Bottom_Up_Semantics#nested-subgroups.
It seems virtuoso doesn't respect the semantics with BIND and subqueries.  In the original query, we assumed `?conversation` wouldn't be bound in the subquery. But Virtuoso did
Here we changed the bind statement to evaluate explicitly in the sub-query
