### PR TITLE
Removing "dossierbehandelaar" when mass mailings

### DIFF
--- a/kalliope_adapter.py
+++ b/kalliope_adapter.py
@@ -178,10 +178,7 @@ def parse_kalliope_poststuk_uit(ps_uit, session):
     betreft = ps_uit['betreft']
     type_communicatie = ps_uit['typeCommunicatie']
     reactietermijn = "P30D"
-    dossierbehandelaar = {
-        'identifier': ps_uit['dossierbehandelaar']['id'],
-        'email': ps_uit['dossierbehandelaar']['email'],
-    }
+    dossierbehandelaar = '' if ps_uit['typePoststuk'] == 'https://kalliope.abb.vlaanderen.be/ld/algemeen/dossierType/omzendbrief' else { 'identifier': ps_uit['dossierbehandelaar']['id'], 'email': ps_uit['dossierbehandelaar']['email'], }
 
     bericht = new_bericht(verzonden, ontvangen, van, naar, inhoud, type_communicatie, dossierbehandelaar)
     bericht['uri'] = ps_uit['uri']

--- a/kalliope_adapter.py
+++ b/kalliope_adapter.py
@@ -178,7 +178,7 @@ def parse_kalliope_poststuk_uit(ps_uit, session):
     betreft = ps_uit['betreft']
     type_communicatie = ps_uit['typeCommunicatie']
     reactietermijn = "P30D"
-    dossierbehandelaar = '' if ps_uit['typePoststuk'] == 'https://kalliope.abb.vlaanderen.be/ld/algemeen/dossierType/omzendbrief' else { 'identifier': ps_uit['dossierbehandelaar']['id'], 'email': ps_uit['dossierbehandelaar']['email'], }
+    dossierbehandelaar = '' if ps_uit['dossierType'] == 'https://kalliope.abb.vlaanderen.be/ld/algemeen/dossierType/omzendbrief' else { 'identifier': ps_uit['dossierbehandelaar']['id'], 'email': ps_uit['dossierbehandelaar']['email'], }
 
     bericht = new_bericht(verzonden, ontvangen, van, naar, inhoud, type_communicatie, dossierbehandelaar)
     bericht['uri'] = ps_uit['uri']


### PR DESCRIPTION
# Description

DL-5629

This PR removes "dossierbehandelaar" only when "omzendbriven" (mass mailings)

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A

# How to test 

- Tested on ACC

# What to check

- N/A

# Links to other PR's

- https://github.com/lblod/app-digitaal-loket/pull/537

# Notes

- Make a Release