### PR TITLE
Adding case when URL should be erediensten toezichtdatabank

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Required environment variables:
 * `KALLIOPE_PS_UIT_CONFIRMATION_ENDPOINT`
 * `KALLIOPE_PS_IN_ENDPOINT`
 * `INZENDING_BASE_URL`
+* `EREDIENSTEN_BASE_URL`
 * `BERICHTEN_CRON_PATTERN`: Pattern of the cron job that polls the API for berichten
 * `BERICHTEN_IN_CONFIRMATION_CRON_PATTERN`: Pattern of the cron job that sends confirmations
 * `INZENDINGEN_CRON_PATTERN`: Pattern of the cron job that sends inzendingen

--- a/task_process_inzendingen_voor_toezicht.py
+++ b/task_process_inzendingen_voor_toezicht.py
@@ -25,6 +25,7 @@ PUBLIC_GRAPH = "http://mu.semte.ch/graphs/public"
 INZENDING_IN_PATH = os.environ.get('KALLIOPE_PS_IN_ENDPOINT')
 MAX_SENDING_ATTEMPTS = int(os.environ.get('MAX_SENDING_ATTEMPTS'))
 INZENDING_BASE_URL = os.environ.get('INZENDING_BASE_URL')
+EREDIENSTEN_BASE_URL = os.environ.get('EREDIENSTEN_BASE_URL')
 
 
 def process_inzendingen():
@@ -95,12 +96,14 @@ def parse_inzending_sparql_response(inzending_res):
         session_date = session_date.astimezone(TIMEZONE)
         session_date = session_date.strftime('%Y-%m-%d')
 
+    erediensten_databank_flow_only = inzending_res['decisionType']['value'] in ['https://data.vlaanderen.be/id/concept/BesluitDocumentType/14793940-5b9c-4172-b108-c73665ad9d6a', 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/651525f8-8650-4ce8-8eea-f19b94d50b73']
+
     inzending = {
         'uri': inzending_res['inzending']['value'],
         'afzenderUri': inzending_res['bestuurseenheid']['value'],
         'betreft': inzending_res['decisionTypeLabel']['value'] + ' ' +
           session_date,
-        'urlToezicht': INZENDING_BASE_URL + '/' + inzending_res['inzendingUuid']['value'],
+        'urlToezicht': EREDIENSTEN_BASE_URL + '/' + inzending_res['inzendingUuid']['value'] if erediensten_databank_flow_only else INZENDING_BASE_URL + '/' + inzending_res['inzendingUuid']['value'],
         'typePoststuk': 'https://kalliope.abb.vlaanderen.be/ld/algemeen/dossierType/besluit',
         'typeMelding': inzending_res['decisionType']['value'],
         'datumVanVerzenden': inzending_res['datumVanVerzenden']['value']


### PR DESCRIPTION
# Description

DL-5856 -> DL-5857

Context : Some submissions shouldn't flow to Toezicht ABB (E.g worship ones), hence kalliope still send poststuk-in about it so the link in the email-notification should be changed accordingly.
This PR adds a link to worship-decision-database to match with the context. This is done by checking if listed decisions types are matching.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# Related services

- N/A  

# How to test 

- N/A  

# What to check

- N/A  

# Links to other PR's

- https://github.com/lblod/app-digitaal-loket/pull/573

# Notes

- release + drc up -d berichtencentrum-sync-with-kalliope