### PR TITLE
DL-6705: Improve berichtencentrum-sync-with-kalliope to handle the new rules

### DIFF
--- a/queries.py
+++ b/queries.py
@@ -693,7 +693,7 @@ def construct_unsent_inzendingen_query(max_sending_attempts):
         PREFIX pav:     <http://purl.org/pav/>
         
         SELECT DISTINCT ?inzending ?inzendingUuid ?bestuurseenheid ?decisionType ?sessionDate
-                        ?decisionTypeLabel ?datumVanVerzenden ?boekjaar
+                        ?decisionTypeLabel ?datumVanVerzenden ?boekjaar ?bestuurseenheidType
         WHERE {{
             GRAPH ?g {{
                 ?inzending a meb:Submission ;
@@ -704,6 +704,7 @@ def construct_unsent_inzendingen_query(max_sending_attempts):
                     prov:generated ?formData .
 
                 ?formData dct:type ?decisionType .
+                ?bestuurseenheid besluit:classificatie ?bestuurseenheidType
 
                 OPTIONAL {{ ?formData <http://linkedeconomy.org/ontology#financialYear> ?boekjaar . }}
 

--- a/queries.py
+++ b/queries.py
@@ -765,7 +765,6 @@ def construct_unsent_inzendingen_query(max_sending_attempts):
                     prov:generated ?formData .
 
                 ?formData dct:type ?decisionType .
-                ?bestuurseenheid besluit:classificatie ?bestuurseenheidType .
 
                 OPTIONAL {{ ?formData <http://linkedeconomy.org/ontology#financialYear> ?boekjaar . }}
 
@@ -780,6 +779,8 @@ def construct_unsent_inzendingen_query(max_sending_attempts):
                 BIND(COALESCE(?attempts, ?default_attempts) AS ?result_attempts)
                 FILTER(?result_attempts < {0})
             }}
+
+            ?bestuurseenheid besluit:classificatie ?bestuurseenheidType .
 
             OPTIONAL {{ ?decisionType skos:prefLabel ?decisionTypeLabel }} .
 

--- a/queries.py
+++ b/queries.py
@@ -20,8 +20,11 @@ STATUS_DELIVERED_CONFIRMATION_FAILED = \
 # Inzendingen business rules :  sender classification with decisionType
 
 DECISION_TYPES_EB_HAS_CB = [
-    "<https://data.vlaanderen.be/id/concept/BesluitType/e44c535d-4339-4d15-bdbf-d4be6046de2c>", # Jaarrekening
     "<https://data.vlaanderen.be/id/concept/BesluitDocumentType/2c9ada23-1229-4c7e-a53e-acddc9014e4e>" # Gecoordineerde inzending meerjarenplannen
+]
+
+DECISION_TYPES_EB_HAS_ACTIVE_CB = [
+    "<https://data.vlaanderen.be/id/concept/BesluitType/e44c535d-4339-4d15-bdbf-d4be6046de2c>" # Jaarrekening
 ]
 
 DECISION_TYPES_EB = [
@@ -529,6 +532,39 @@ def verify_eb_has_cb_exclusion_rule(submission):
     """.format(submission, " ".join(DECISION_TYPES_EB_HAS_CB))
 
     return ask_query_eb_has_cb
+
+def verify_eb_has_active_cb_exclusion_rule(submission):
+
+    ask_query_eb_has_active_cb = """
+    PREFIX ere:         <http://data.lblod.info/vocabularies/erediensten/>
+    PREFIX org:         <http://www.w3.org/ns/org#>
+    PREFIX pav:         <http://purl.org/pav/>
+    PREFIX meb:         <http://rdf.myexperiment.org/ontologies/base/>
+    PREFIX dct:         <http://purl.org/dc/terms/>
+    PREFIX prov:        <http://www.w3.org/ns/prov#>
+    PREFIX adms:        <http://www.w3.org/ns/adms#>
+    PREFIX regorg: <http://www.w3.org/ns/regorg#>
+
+    
+    ASK {{
+
+        BIND(<{0}> AS ?submission)
+        ?submission a meb:Submission ;
+                   adms:status <http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c> ;
+                   prov:generated ?formData ;
+                   pav:createdBy ?bestuurseenheid .
+        ?formData dct:type ?decisionType .
+        VALUES ?decisionType {{ {1} }}
+
+        ?bestuurseenheid a ere:BestuurVanDeEredienst.
+
+        ?centraalBestuur a ere:CentraalBestuurVanDeEredienst ;
+                         org:hasSubOrganization ?bestuurseenheid ;
+                         regorg:orgStatus <http://lblod.data.gift/concepts/63cc561de9188d64ba5840a42ae8f0d6> .
+    }}
+    """.format(submission, " ".join(DECISION_TYPES_EB_HAS_ACTIVE_CB))
+
+    return ask_query_eb_has_active_cb
 
 def verify_eb_exclusion_rule(submission):
 

--- a/queries.py
+++ b/queries.py
@@ -663,6 +663,69 @@ def verify_po_exclusion_rule(submission):
 
     return ask_query_po
 
+def verify_mp_exclusion_rule(submission):
+    # Meerjarenplan exclusion if sender is a bestuur van de eredienst
+    ask_query_mp = """
+    PREFIX ere:     <http://data.lblod.info/vocabularies/erediensten/>
+    PREFIX pav:     <http://purl.org/pav/>
+    PREFIX meb:     <http://rdf.myexperiment.org/ontologies/base/>
+    PREFIX dct:     <http://purl.org/dc/terms/>
+    PREFIX prov:    <http://www.w3.org/ns/prov#>
+    PREFIX adms:    <http://www.w3.org/ns/adms#>
+    PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+    
+    ASK {{
+        BIND(<{0}> AS ?submission)
+
+        ?submission a meb:Submission ;
+                    adms:status <http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c> ;
+                    prov:generated ?formData ;
+                    pav:createdBy ?bestuurseenheid .
+
+        ?formData dct:type <https://data.vlaanderen.be/id/concept/BesluitType/f56c645d-b8e1-4066-813d-e213f5bc529f> .
+
+        ?bestuurseenheid besluit:classificatie <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86> .
+    }}
+    """.format(submission)
+
+    return ask_query_mp
+
+def verify_opnavb_exclusion_rule(submission):
+    # Opstart beroepsprocedure naar aanleiding van een beslissing if its (centraal) bestuur van de eredienst, representatief orgaan, gemeente or provincie
+    ask_query_opnavb = """
+    PREFIX ere:     <http://data.lblod.info/vocabularies/erediensten/>
+    PREFIX pav:     <http://purl.org/pav/>
+    PREFIX meb:     <http://rdf.myexperiment.org/ontologies/base/>
+    PREFIX dct:     <http://purl.org/dc/terms/>
+    PREFIX prov:    <http://www.w3.org/ns/prov#>
+    PREFIX adms:    <http://www.w3.org/ns/adms#>
+    PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+    
+    ASK {{
+        BIND(<{0}> AS ?submission)
+
+        ?submission a meb:Submission ;
+                    adms:status <http://lblod.data.gift/concepts/9bd8d86d-bb10-4456-a84e-91e9507c374c> ;
+                    prov:generated ?formData ;
+                    pav:createdBy ?bestuurseenheid .
+
+        ?formData dct:type <https://data.vlaanderen.be/id/concept/BesluitDocumentType/802a7e56-54f8-488d-b489-4816321fb9ae> .
+
+        ?bestuurseenheid besluit:classificatie ?bestuurseenheidType .
+
+        VALUES ?bestuurseenheidType {{
+            <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86>
+            <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054>
+            <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213>
+            <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001>
+            <http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000>
+        }}
+    }}
+    """.format(submission)
+
+    return ask_query_opnavb
+
+
 
 def construct_unsent_inzendingen_query(max_sending_attempts):
     """

--- a/queries.py
+++ b/queries.py
@@ -704,7 +704,7 @@ def construct_unsent_inzendingen_query(max_sending_attempts):
                     prov:generated ?formData .
 
                 ?formData dct:type ?decisionType .
-                ?bestuurseenheid besluit:classificatie ?bestuurseenheidType
+                ?bestuurseenheid besluit:classificatie ?bestuurseenheidType .
 
                 OPTIONAL {{ ?formData <http://linkedeconomy.org/ontology#financialYear> ?boekjaar . }}
 

--- a/queries.py
+++ b/queries.py
@@ -725,8 +725,6 @@ def verify_opnavb_exclusion_rule(submission):
 
     return ask_query_opnavb
 
-
-
 def construct_unsent_inzendingen_query(max_sending_attempts):
     """
     Construct a SPARQL query for retrieving all messages for a given recipient that haven't been received yet by the other party.

--- a/task_process_inzendingen_voor_toezicht.py
+++ b/task_process_inzendingen_voor_toezicht.py
@@ -88,6 +88,56 @@ def process_inzendingen():
                 log(message)
     pass
 
+def determine_url(inzending_res):
+    """
+    Determine the correct URL for 'urlToezicht'.
+    """
+    # Rules to decide if it should be worship based
+    RULES = [
+        #Gemeente / Provincie
+        {
+            "decisionType": ["https://data.vlaanderen.be/id/concept/BesluitDocumentType/4f938e44-8bce-4d3a-b5a7-b84754fe981a", "https://data.vlaanderen.be/id/concept/BesluitType/79414af4-4f57-4ca3-aaa4-f8f1e015e71c"],
+            "bestuurseenheidType": ["https://data.vlaanderen.be/doc/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001", "https://data.vlaanderen.be/doc/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000"]
+        },
+        # Bestuur van de eredienst
+        {
+            "decisionType": ["https://data.vlaanderen.be/id/concept/BesluitDocumentType/a970c99d-c06c-4942-9815-153bf3e87df2",
+                            "https://data.vlaanderen.be/id/concept/BesluitType/54b61cbd-349f-41c4-9c8a-7e8e67d08347",
+                            "https://data.vlaanderen.be/id/concept/BesluitType/e44c535d-4339-4d15-bdbf-d4be6046de2c"],
+            "bestuurseenheidType": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86"
+        },
+        #Centraal bestuur van de eredienst
+        {
+            "decisionType": "https://data.vlaanderen.be/id/concept/BesluitDocumentType/672bf096-dccd-40af-ab60-bd7de15cc461",
+            "bestuurseenheidType": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054"
+        },
+        # Representatief orgaan
+        {
+            "decisionType": ["https://data.vlaanderen.be/id/concept/BesluitDocumentType/651525f8-8650-4ce8-8eea-f19b94d50b73",
+                            "https://data.vlaanderen.be/id/concept/BesluitDocumentType/d611364b-007b-49a7-b2bf-b8f4e5568777",
+                            "https://data.vlaanderen.be/id/concept/BesluitDocumentType/6d1a3aea-6773-4e10-924d-38be596c5e2e",
+                            "https://data.vlaanderen.be/id/concept/BesluitDocumentType/14793940-5b9c-4172-b108-c73665ad9d6a",
+                            "https://data.vlaanderen.be/id/concept/BesluitDocumentType/95a6c5a1-05af-4d48-b2ef-5ebb1e58783b"],
+            "bestuurseenheidType": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213"
+        },
+        # (Centraal) bestuur van de eredienst
+        {
+            "decisionType": "https://data.vlaanderen.be/id/concept/BesluitType/41a09f6c-7964-4777-8375-437ef61ed946",
+            "bestuurseenheidType": ["http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86", "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054"]
+        },
+    ]
+
+    decision_type = inzending_res['decisionType']['value']
+    afzender_class = inzending_res['bestuurseenheidType']['value']
+
+    # Make URL
+    for rule in RULES:
+        if decision_type == rule['decisionType'] and afzender_class in rule['bestuurseenheidType']:
+            return EREDIENSTEN_BASE_URL + '/' + inzending_res['inzendingUuid']['value']
+        elif inzending_res['decisionType']['value'] in ['https://data.vlaanderen.be/id/concept/BesluitType/95c671c2-3ab7-43e2-a90d-9b096c84bfe7']:
+            return EREDIENSTEN_BASE_URL + '/' + inzending_res['inzendingUuid']['value']
+        else:
+            return INZENDING_BASE_URL + '/' + inzending_res['inzendingUuid']['value']
 
 def parse_inzending_sparql_response(inzending_res):
     session_date = inzending_res.get('sessionDate', {}).get('value', '')
@@ -96,14 +146,12 @@ def parse_inzending_sparql_response(inzending_res):
         session_date = session_date.astimezone(TIMEZONE)
         session_date = session_date.strftime('%Y-%m-%d')
 
-    erediensten_databank_flow_only = inzending_res['decisionType']['value'] in ['https://data.vlaanderen.be/id/concept/BesluitDocumentType/14793940-5b9c-4172-b108-c73665ad9d6a', 'https://data.vlaanderen.be/id/concept/BesluitDocumentType/651525f8-8650-4ce8-8eea-f19b94d50b73', 'https://data.vlaanderen.be/id/concept/BesluitType/95c671c2-3ab7-43e2-a90d-9b096c84bfe7']
-
     inzending = {
         'uri': inzending_res['inzending']['value'],
         'afzenderUri': inzending_res['bestuurseenheid']['value'],
         'betreft': inzending_res['decisionTypeLabel']['value'] + ' ' +
           session_date,
-        'urlToezicht': EREDIENSTEN_BASE_URL + '/' + inzending_res['inzendingUuid']['value'] if erediensten_databank_flow_only else INZENDING_BASE_URL + '/' + inzending_res['inzendingUuid']['value'],
+        'urlToezicht': determine_url(inzending_res),
         'typePoststuk': 'https://kalliope.abb.vlaanderen.be/ld/algemeen/dossierType/besluit',
         'typeMelding': inzending_res['decisionType']['value'],
         'datumVanVerzenden': inzending_res['datumVanVerzenden']['value']

--- a/task_process_inzendingen_voor_toezicht.py
+++ b/task_process_inzendingen_voor_toezicht.py
@@ -95,36 +95,26 @@ def determine_url(inzending_res):
     # Rules to decide if it should be worship based
     RULES = [
         #Gemeente / Provincie
-        {
-            "decisionType": ["https://data.vlaanderen.be/id/concept/BesluitDocumentType/4f938e44-8bce-4d3a-b5a7-b84754fe981a", "https://data.vlaanderen.be/id/concept/BesluitType/79414af4-4f57-4ca3-aaa4-f8f1e015e71c"],
-            "bestuurseenheidType": ["https://data.vlaanderen.be/doc/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001", "https://data.vlaanderen.be/doc/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000"]
-        },
+        {"decisionType": ["https://data.vlaanderen.be/id/concept/BesluitDocumentType/4f938e44-8bce-4d3a-b5a7-b84754fe981a", "https://data.vlaanderen.be/id/concept/BesluitType/79414af4-4f57-4ca3-aaa4-f8f1e015e71c"],
+            "bestuurseenheidType": ["https://data.vlaanderen.be/doc/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001", "https://data.vlaanderen.be/doc/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000"]},
         # Bestuur van de eredienst
-        {
-            "decisionType": ["https://data.vlaanderen.be/id/concept/BesluitDocumentType/a970c99d-c06c-4942-9815-153bf3e87df2",
+        {"decisionType": ["https://data.vlaanderen.be/id/concept/BesluitDocumentType/a970c99d-c06c-4942-9815-153bf3e87df2",
                             "https://data.vlaanderen.be/id/concept/BesluitType/54b61cbd-349f-41c4-9c8a-7e8e67d08347",
                             "https://data.vlaanderen.be/id/concept/BesluitType/e44c535d-4339-4d15-bdbf-d4be6046de2c"],
-            "bestuurseenheidType": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86"
-        },
+            "bestuurseenheidType": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86"},
         #Centraal bestuur van de eredienst
-        {
-            "decisionType": "https://data.vlaanderen.be/id/concept/BesluitDocumentType/672bf096-dccd-40af-ab60-bd7de15cc461",
-            "bestuurseenheidType": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054"
-        },
+        {"decisionType": "https://data.vlaanderen.be/id/concept/BesluitDocumentType/672bf096-dccd-40af-ab60-bd7de15cc461",
+            "bestuurseenheidType": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054"},
         # Representatief orgaan
-        {
-            "decisionType": ["https://data.vlaanderen.be/id/concept/BesluitDocumentType/651525f8-8650-4ce8-8eea-f19b94d50b73",
+        {"decisionType": ["https://data.vlaanderen.be/id/concept/BesluitDocumentType/651525f8-8650-4ce8-8eea-f19b94d50b73",
                             "https://data.vlaanderen.be/id/concept/BesluitDocumentType/d611364b-007b-49a7-b2bf-b8f4e5568777",
                             "https://data.vlaanderen.be/id/concept/BesluitDocumentType/6d1a3aea-6773-4e10-924d-38be596c5e2e",
                             "https://data.vlaanderen.be/id/concept/BesluitDocumentType/14793940-5b9c-4172-b108-c73665ad9d6a",
                             "https://data.vlaanderen.be/id/concept/BesluitDocumentType/95a6c5a1-05af-4d48-b2ef-5ebb1e58783b"],
-            "bestuurseenheidType": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213"
-        },
+            "bestuurseenheidType": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213"},
         # (Centraal) bestuur van de eredienst
-        {
-            "decisionType": "https://data.vlaanderen.be/id/concept/BesluitType/41a09f6c-7964-4777-8375-437ef61ed946",
-            "bestuurseenheidType": ["http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86", "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054"]
-        },
+        {"decisionType": "https://data.vlaanderen.be/id/concept/BesluitType/41a09f6c-7964-4777-8375-437ef61ed946",
+            "bestuurseenheidType": ["http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86", "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054"]},
     ]
 
     decision_type = inzending_res['decisionType']['value']

--- a/task_process_inzendingen_voor_toezicht.py
+++ b/task_process_inzendingen_voor_toezicht.py
@@ -9,6 +9,7 @@ from .queries import construct_unsent_inzendingen_query
 from .queries import construct_increment_inzending_attempts_query
 from .queries import construct_inzending_sent_query
 from .queries import construct_create_kalliope_sync_error_query
+from .queries import verify_eb_has_active_cb_exclusion_rule
 from .queries import verify_eb_has_cb_exclusion_rule
 from .queries import verify_eb_exclusion_rule
 from .queries import verify_cb_exclusion_rule
@@ -179,6 +180,7 @@ def exclude_inzendingen_from_rules(inzendingen):
         submission = inzending['inzending']['value']
 
         eb_has_cb = query(verify_eb_has_cb_exclusion_rule(submission))['boolean']
+        eb_has_active_cb = query(verify_eb_has_active_cb_exclusion_rule(submission))['boolean']
         eb = query(verify_eb_exclusion_rule(submission))['boolean']
         cb = query(verify_cb_exclusion_rule(submission))['boolean']
         ro = query(verify_ro_exclusion_rule(submission))['boolean']
@@ -187,7 +189,7 @@ def exclude_inzendingen_from_rules(inzendingen):
         mp = query(verify_mp_exclusion_rule(submission))['boolean'] 
         opnavb = query(verify_opnavb_exclusion_rule(submission))['boolean'] 
 
-        if not (eb_has_cb or eb or cb or ro or go or po or mp or opnavb):
+        if not (eb_has_cb or eb_has_active_cb or eb or cb or ro or go or po or mp or opnavb):
             filtered_inzendingen.append(inzending)
 
     return filtered_inzendingen

--- a/task_process_inzendingen_voor_toezicht.py
+++ b/task_process_inzendingen_voor_toezicht.py
@@ -98,7 +98,7 @@ def determine_url(inzending_res):
     RULES = [
         #Gemeente / Provincie
         {"decisionType": ["https://data.vlaanderen.be/id/concept/BesluitDocumentType/4f938e44-8bce-4d3a-b5a7-b84754fe981a", "https://data.vlaanderen.be/id/concept/BesluitType/79414af4-4f57-4ca3-aaa4-f8f1e015e71c", "https://data.vlaanderen.be/id/concept/BesluitType/b25faa84-3ab5-47ae-98c0-1b389c77b827"],
-            "bestuurseenheidType": ["https://data.vlaanderen.be/doc/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001", "https://data.vlaanderen.be/doc/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000"]},
+            "bestuurseenheidType": ["http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001", "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000"]},
         # Bestuur van de eredienst
         {"decisionType": ["https://data.vlaanderen.be/id/concept/BesluitDocumentType/a970c99d-c06c-4942-9815-153bf3e87df2",
                             "https://data.vlaanderen.be/id/concept/BesluitType/54b61cbd-349f-41c4-9c8a-7e8e67d08347",

--- a/task_process_inzendingen_voor_toezicht.py
+++ b/task_process_inzendingen_voor_toezicht.py
@@ -121,15 +121,21 @@ def determine_url(inzending_res):
 
     decision_type = inzending_res['decisionType']['value']
     afzender_class = inzending_res['bestuurseenheidType']['value']
+    url = INZENDING_BASE_URL + '/' + inzending_res['inzendingUuid']['value']
 
-    # Make URL
     for rule in RULES:
-        if decision_type == rule['decisionType'] and afzender_class in rule['bestuurseenheidType']:
-            return EREDIENSTEN_BASE_URL + '/' + inzending_res['inzendingUuid']['value']
-        elif inzending_res['decisionType']['value'] in ['https://data.vlaanderen.be/id/concept/BesluitType/95c671c2-3ab7-43e2-a90d-9b096c84bfe7']:
-            return EREDIENSTEN_BASE_URL + '/' + inzending_res['inzendingUuid']['value']
-        else:
-            return INZENDING_BASE_URL + '/' + inzending_res['inzendingUuid']['value']
+        rule_decision_types = rule['decisionType'] if isinstance(rule['decisionType'], list) else [rule['decisionType']]
+        rule_bestuurseenheid_types = rule['bestuurseenheidType'] if isinstance(rule['bestuurseenheidType'], list) else [rule['bestuurseenheidType']]
+
+        # update URL if rule matches
+        if decision_type in rule_decision_types and afzender_class in rule_bestuurseenheid_types:
+            url = EREDIENSTEN_BASE_URL + '/' + inzending_res['inzendingUuid']['value']
+
+    # special case override
+    if decision_type == 'https://data.vlaanderen.be/id/concept/BesluitType/95c671c2-3ab7-43e2-a90d-9b096c84bfe7':
+        url = EREDIENSTEN_BASE_URL + '/' + inzending_res['inzendingUuid']['value']
+
+    return url
 
 def parse_inzending_sparql_response(inzending_res):
     session_date = inzending_res.get('sessionDate', {}).get('value', '')

--- a/task_process_inzendingen_voor_toezicht.py
+++ b/task_process_inzendingen_voor_toezicht.py
@@ -15,6 +15,8 @@ from .queries import verify_cb_exclusion_rule
 from .queries import verify_ro_exclusion_rule
 from .queries import verify_go_exclusion_rule
 from .queries import verify_po_exclusion_rule
+from .queries import verify_mp_exclusion_rule
+from .queries import verify_opnavb_exclusion_rule
 from .update_with_supressed_fail import update_with_suppressed_fail
 from dateutil import parser
 
@@ -176,9 +178,11 @@ def exclude_inzendingen_from_rules(inzendingen):
         ro = query(verify_ro_exclusion_rule(submission))['boolean']
         go = query(verify_go_exclusion_rule(submission))['boolean']
         po = query(verify_po_exclusion_rule(submission))['boolean']
+        mp = query(verify_mp_exclusion_rule(submission))['boolean'] 
+        opnavb = query(verify_opnavb_exclusion_rule(submission))['boolean'] 
 
-
-        if not (eb_has_cb or eb or cb or ro or go or po):
+        if not (eb_has_cb or eb or cb or ro or go or po or mp or opnavb):
             filtered_inzendingen.append(inzending)
 
     return filtered_inzendingen
+

--- a/task_process_inzendingen_voor_toezicht.py
+++ b/task_process_inzendingen_voor_toezicht.py
@@ -97,7 +97,7 @@ def determine_url(inzending_res):
     # Rules to decide if it should be worship based
     RULES = [
         #Gemeente / Provincie
-        {"decisionType": ["https://data.vlaanderen.be/id/concept/BesluitDocumentType/4f938e44-8bce-4d3a-b5a7-b84754fe981a", "https://data.vlaanderen.be/id/concept/BesluitType/79414af4-4f57-4ca3-aaa4-f8f1e015e71c"],
+        {"decisionType": ["https://data.vlaanderen.be/id/concept/BesluitDocumentType/4f938e44-8bce-4d3a-b5a7-b84754fe981a", "https://data.vlaanderen.be/id/concept/BesluitType/79414af4-4f57-4ca3-aaa4-f8f1e015e71c", "https://data.vlaanderen.be/id/concept/BesluitType/b25faa84-3ab5-47ae-98c0-1b389c77b827"],
             "bestuurseenheidType": ["https://data.vlaanderen.be/doc/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000001", "https://data.vlaanderen.be/doc/concept/BestuurseenheidClassificatieCode/5ab0e9b8a3b2ca7c5e000000"]},
         # Bestuur van de eredienst
         {"decisionType": ["https://data.vlaanderen.be/id/concept/BesluitDocumentType/a970c99d-c06c-4942-9815-153bf3e87df2",


### PR DESCRIPTION
This PR includes the following changes:

- Added bestuurseenheidType to query to use in .py file.

- Adjusted the function for the urlToezicht so that it follows the rules of the Excel. One change from the excel is that Schorsing beslissing eredienstbesturen is also a 'yes' for Post-In to Kalliope, since this was asked in a comment. 

- Added two exclusion rules so that:
    - Meerjarenplan(aanpassing) wont be send if it's bestuur van eredienst
    - Opstart beroepsprocedure naar aanleiding van een beslissing won´t be send if its one of the Excel mentioned ones.
Since both were no in the Excel.  

There is also a condition for jaarrekening that it can only be send if EB has no active CB. In my opinion this is already included in the exclusion queries via: https://github.com/lblod/berichtencentrum-sync-with-kalliope-service/blob/master/queries.py#L503

### Ticket
DL-6705 (find the Excel mentioned also via this ticket)