### PR TITLE
Workaround: fix 'double' meldingen to kalliope

### DIFF
--- a/task_process_inzendingen_voor_toezicht.py
+++ b/task_process_inzendingen_voor_toezicht.py
@@ -44,6 +44,12 @@ def process_inzendingen():
     filtered_inzendingen = exclude_inzendingen_from_rules(inzendingen)
 
     inzendingen = [parse_inzending_sparql_response(inzending_res) for inzending_res in filtered_inzendingen]
+
+    # Ensure the inzending to be sent are unique.
+    # This is currently a workaround since there are problems in the data, and previous queries sometimes
+    # returns 'double' results. seeAlso: DL-6946
+    inzendingen = list({inzending['uri']: inzending for inzending in inzendingen}.values())
+
     log("Found {} submissions that need to be sent to the Kalliope API".format(len(inzendingen)))
     if len(inzendingen) == 0:
         return


### PR DESCRIPTION
Workaround that submissions get posted to kalliope only once.
The root cause here is that for Representative organs, we have 2 classifications -which the app depends on- and thus some queries return multiple lines. We can't change the data like that, so we'll have to grind with the workaround for now.

https://binnenland.atlassian.net/browse/DL-6946