### PR TITLE
DL-7083: ERE Kalliope post-in: sometimes the URL still refers to Databank Toezicht

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## Unreleased
+- Fix on the notification rules to kalliope
 ## 0.23.0 (2025-10-08)
 - Big change on the notification rules to kalliope and it's content
   - See also: https://binnenland.atlassian.net/browse/DL-6705

--- a/task_process_inzendingen_voor_toezicht.py
+++ b/task_process_inzendingen_voor_toezicht.py
@@ -120,7 +120,7 @@ def determine_url(inzending_res):
                             "https://data.vlaanderen.be/id/concept/BesluitDocumentType/6d1a3aea-6773-4e10-924d-38be596c5e2e",
                             "https://data.vlaanderen.be/id/concept/BesluitDocumentType/14793940-5b9c-4172-b108-c73665ad9d6a",
                             "https://data.vlaanderen.be/id/concept/BesluitDocumentType/95a6c5a1-05af-4d48-b2ef-5ebb1e58783b"],
-            "bestuurseenheidType": "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213"},
+            "bestuurseenheidType": ["http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/36372fad-0358-499c-a4e3-f412d2eae213", "http://data.vlaanderen.be/id/concept/RepresentatiefOrgaanClassificatieCode/89a00b5a-024f-4630-a722-65a5e68967e5"]},
         # (Centraal) bestuur van de eredienst
         {"decisionType": "https://data.vlaanderen.be/id/concept/BesluitType/41a09f6c-7964-4777-8375-437ef61ed946",
             "bestuurseenheidType": ["http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/66ec74fd-8cfc-4e16-99c6-350b35012e86", "http://data.vlaanderen.be/id/concept/BestuurseenheidClassificatieCode/f9cac08a-13c1-49da-9bcb-f650b0604054"]},


### PR DESCRIPTION
Had to change the URI for bestuurseenheid cuz sometimes Representatief Orgaan has another one. 

### Test

1. Make a new instance in Toezicht (digitaal loket). Make sure this service is set to this change
2. Look at the logs of this service and look at what URI it put's out. This should start with https://databankerediensten.lokaalbestuur.vlaanderen.be and not with https://besluiten.abb.vlaanderen.be